### PR TITLE
Passed and failed tests property

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,3 +304,30 @@ df_tester.summary.show(truncate=False)
     |house_number__ValidNumericRange|house_number__ValidNumericRange(min_value=0.0, max_value=inf)|5      |4       |80.0             |1       |20.0             |
     |has_bath_room                  |House has a bath room                                        |2      |1       |50.0             |1       |50.0             |
     +-------------------------------+-------------------------------------------------------------+-------+--------+-----------------+--------+-----------------+
+
+**If you want to see all rows that failed any of the tests, you can use the `.failed_tests` attribute.**
+
+```python
+df_tester.failed_tests.show(truncate=False)
+```
+
+    +-----------+-----------------------+-------------------------------+-------------+
+    |primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|
+    +-----------+-----------------------+-------------------------------+-------------+
+    |2          |true                   |true                           |false        |
+    |3          |false                  |true                           |null         |
+    |4          |true                   |false                          |null         |
+    |5          |false                  |true                           |null         |
+    +-----------+-----------------------+-------------------------------+-------------+
+
+**Of course, you can also see all rows that passed all tests using the `.passed_tests` attribute.**
+
+```python
+df_tester.passed_tests.show(truncate=False)
+```
+
+    +-----------+-----------------------+-------------------------------+-------------+
+    |primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|
+    +-----------+-----------------------+-------------------------------+-------------+
+    |1          |true                   |true                           |true         |
+    +-----------+-----------------------+-------------------------------+-------------+

--- a/tests/dataquality/dataframe/test_DataFrameTester.py
+++ b/tests/dataquality/dataframe/test_DataFrameTester.py
@@ -246,3 +246,17 @@ def test_summary_empty_df(spark):
 
     # Expect no rows in the summary DataFrame for an empty input DataFrame
     assert summary_df.count() == 0
+
+
+def test_passed_tests(sample_df, spark):
+    tester = DataFrameTester(df=sample_df, primary_key="id", spark=spark)
+    tester.test(col="value", test=ValidNumericRange(min_value=11), nullable=True)
+
+    assert tester.passed_tests.count() == 3
+
+
+def test_failed_tests(sample_df, spark):
+    tester = DataFrameTester(df=sample_df, primary_key="id", spark=spark)
+    tester.test(col="value", test=ValidNumericRange(min_value=11), nullable=True)
+
+    assert tester.failed_tests.count() == 1

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -44,7 +44,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "24/08/12 11:59:24 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "24/08/12 14:43:33 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "+-----------+--------------------+------------+\n",
       "|primary_key|street              |house_number|\n",
       "+-----------+--------------------+------------+\n",
@@ -55,13 +68,6 @@
       "|5          |null                |13          |\n",
       "+-----------+--------------------+------------+\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
      ]
     }
    ],
@@ -538,9 +544,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CodeCache: size=131072Kb used=36977Kb max_used=37003Kb free=94094Kb\n",
-      " bounds [0x00000001069e8000, 0x0000000108e48000, 0x000000010e9e8000]\n",
-      " total_blobs=13317 nmethods=12406 adapters=821\n",
+      "CodeCache: size=131072Kb used=36992Kb max_used=37010Kb free=94079Kb\n",
+      " bounds [0x000000010b1e8000, 0x000000010d658000, 0x00000001131e8000]\n",
+      " total_blobs=13403 nmethods=12493 adapters=821\n",
       " compilation: disabled (not enough contiguous free space left)\n",
       "+-------------------------------+-------------------------------------------------------------+-------+--------+-----------------+--------+-----------------+\n",
       "|test                           |description                                                  |n_tests|n_passed|percentage_passed|n_failed|percentage_failed|\n",
@@ -555,6 +561,67 @@
    ],
    "source": [
     "df_tester.summary.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**If you want to see all rows that failed any of the tests, you can use the `.failed_tests` attribute.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "|primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|\n",
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "|2          |true                   |true                           |false        |\n",
+      "|3          |false                  |true                           |null         |\n",
+      "|4          |true                   |false                          |null         |\n",
+      "|5          |false                  |true                           |null         |\n",
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_tester.failed_tests.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Of course, you can also see all rows that passed all tests using the `.passed_tests` attribute.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "|primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|\n",
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "|1          |true                   |true                           |true         |\n",
+      "+-----------+-----------------------+-------------------------------+-------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_tester.passed_tests.show(truncate=False)"
    ]
   }
  ],


### PR DESCRIPTION
Adds `passed_tests` and `failed_tests` properties to `DataFrameTester` to get respectively all rows without and with any failed test