### PR TITLE
Add `return_failed_rows` Parameter to DataFrameTester Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ df_tester.test(
 
 **Run the `IntegerString` test on the _number_ column**
 
+By setting the `return_failed_rows` parameter to `True`, we can get only the rows that failed the test.
+
 ```python
 df_tester.test(
     col="house_number",
@@ -129,17 +131,14 @@ df_tester.test(
     ),
     nullable=True,  # nullable, hence null values are converted to True
     # description is optional, let's not define it for illustration purposes
+    return_failed_rows=True # only return the failed rows
 ).show()
 ```
 
     +-----------+------------+-------------------------------+
     |primary_key|house_number|house_number__ValidNumericRange|
     +-----------+------------+-------------------------------+
-    |          1|          27|                           true|
-    |          2|          31|                           true|
-    |          3|          27|                           true|
     |          4|          -3|                          false|
-    |          5|          13|                           true|
     +-----------+------------+-------------------------------+
 
 **Let's take a look at the test results of the DataFrame using the `.results` attribute.**
@@ -330,4 +329,8 @@ df_tester.passed_tests.show(truncate=False)
     |primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|
     +-----------+-----------------------+-------------------------------+-------------+
     |1          |true                   |true                           |true         |
+    |2          |true                   |true                           |false        |
+    |3          |false                  |true                           |null         |
+    |4          |true                   |false                          |null         |
+    |5          |false                  |true                           |null         |
     +-----------+-----------------------+-------------------------------+-------------+

--- a/tests/dataquality/dataframe/test_DataFrameTester.py
+++ b/tests/dataquality/dataframe/test_DataFrameTester.py
@@ -260,3 +260,31 @@ def test_failed_tests(sample_df, spark):
     tester.test(col="value", test=ValidNumericRange(min_value=11), nullable=True)
 
     assert tester.failed_tests.count() == 1
+
+
+def test_return_failed_rows(sample_df, spark):
+    tester = DataFrameTester(df=sample_df, primary_key="id", spark=spark)
+    test_result = tester.test(
+        col="value",
+        test=ValidNumericRange(min_value=11),
+        nullable=True,
+        return_failed_rows=True,
+    )
+    assert test_result.count() == 1
+
+
+def test_return_failed_rows_custom_test(sample_df, spark):
+    tester = DataFrameTester(df=sample_df, primary_key="id", spark=spark)
+    custom_test_data = [(1, True), (2, False), (3, True), (4, False)]
+    custom_test_columns = ["id", "custom_test"]
+    custom_test_result = spark.createDataFrame(custom_test_data, custom_test_columns)
+
+    updated_results = tester.add_custom_test_result(
+        result=custom_test_result,
+        name="custom_test",
+        description="This is a custom test",
+        fillna_value=False,
+        return_failed_rows=True,
+    )
+
+    assert updated_results.count() == 2

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -44,7 +44,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "24/08/12 14:43:33 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "24/08/13 10:03:39 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     },
     {
@@ -204,7 +204,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Run the `IntegerString` test on the _number_ column**"
+    "**Run the `IntegerString` test on the _number_ column**\n",
+    "\n",
+    "By setting the `return_failed_rows` parameter to `True`, we can get only the rows that failed the test."
    ]
   },
   {
@@ -219,11 +221,7 @@
       "+-----------+------------+-------------------------------+\n",
       "|primary_key|house_number|house_number__ValidNumericRange|\n",
       "+-----------+------------+-------------------------------+\n",
-      "|          1|          27|                           true|\n",
-      "|          2|          31|                           true|\n",
-      "|          3|          27|                           true|\n",
       "|          4|          -3|                          false|\n",
-      "|          5|          13|                           true|\n",
       "+-----------+------------+-------------------------------+\n",
       "\n"
      ]
@@ -237,6 +235,7 @@
     "    ),\n",
     "    nullable=True,  # nullable, hence null values are converted to True\n",
     "    # description is optional, let's not define it for illustration purposes\n",
+    "    return_failed_rows=True,  # only return the failed rows\n",
     ").show()"
    ]
   },
@@ -533,21 +532,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Java HotSpot(TM) 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.\n",
-      "Java HotSpot(TM) 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CodeCache: size=131072Kb used=36992Kb max_used=37010Kb free=94079Kb\n",
-      " bounds [0x000000010b1e8000, 0x000000010d658000, 0x00000001131e8000]\n",
-      " total_blobs=13403 nmethods=12493 adapters=821\n",
-      " compilation: disabled (not enough contiguous free space left)\n",
       "+-------------------------------+-------------------------------------------------------------+-------+--------+-----------------+--------+-----------------+\n",
       "|test                           |description                                                  |n_tests|n_passed|percentage_passed|n_failed|percentage_failed|\n",
       "+-------------------------------+-------------------------------------------------------------+-------+--------+-----------------+--------+-----------------+\n",
@@ -615,6 +602,10 @@
       "|primary_key|street__ValidStreetName|house_number__ValidNumericRange|has_bath_room|\n",
       "+-----------+-----------------------+-------------------------------+-------------+\n",
       "|1          |true                   |true                           |true         |\n",
+      "|2          |true                   |true                           |false        |\n",
+      "|3          |false                  |true                           |null         |\n",
+      "|4          |true                   |false                          |null         |\n",
+      "|5          |false                  |true                           |null         |\n",
       "+-----------+-----------------------+-------------------------------+-------------+\n",
       "\n"
      ]


### PR DESCRIPTION
This pull request introduces the `return_failed_rows` parameter to the `DataFrameTester` class methods, enhancing the flexibility and usability of data testing within the framework.

**Key Changes:**

1. **New Parameter Addition:**
   - Added the `return_failed_rows` parameter to the following methods of `DataFrameTester`:
     - `test()`
     - `add_custom_test_result()`
   - This parameter allows users to retrieve only the rows that failed a particular test, streamlining the debugging and data quality assessment process.

2. **Documentation Updates:**
   - Updated the README and tutorial notebook to include explanations and usage examples of the new `return_failed_rows` parameter.
   - Provided illustrative examples to demonstrate how to leverage this feature effectively.

3. **Unit Tests:**
   - Introduced new unit tests in `test_DataFrameTester.py` to validate the functionality of the `return_failed_rows` parameter for both standard and custom tests.
   - Ensured that the tests accurately capture and return the failed rows as expected.

4. **Tutorial Enhancements:**
   - Modified the tutorial notebook to incorporate the usage of the `return_failed_rows` parameter, offering users hands-on guidance on its application.

**Implications:**

The addition of the `return_failed_rows` parameter empowers users to focus on problematic data subsets efficiently. By filtering out passed rows, users can prioritize data cleaning and quality improvement tasks, leading to more robust and reliable datasets.