### PR TITLE
added .isNull() for proper null handling in .passed_tests property

### DIFF
--- a/src/testframework/dataquality/dataframe/dataframe_tester.py
+++ b/src/testframework/dataquality/dataframe/dataframe_tester.py
@@ -409,7 +409,7 @@ class DataFrameTester:
             DataFrame: A DataFrame containing only the rows where no test has failed.
         """
         conditions = [
-            F.col(col) != F.lit(False)
+            (F.col(col) != F.lit(False) | F.col(col).isNull())
             for col in self.results.columns[1:]
             if isinstance(self.results.schema[col].dataType, BooleanType)
         ]


### PR DESCRIPTION
This pull request updates the `DataFrameTester` class to handle null values in boolean columns when filtering test results. Previously, rows where the boolean column value was `null` were not filtered correctly. This change modifies the condition to include cases where the value is either `False` or `null`, ensuring accurate filtering of rows when wanting passed tests.

