### PR TITLE
Bug: summary results after filtering

### DIFF
--- a/src/testframework/dataquality/dataframe/dataframe_tester.py
+++ b/src/testframework/dataquality/dataframe/dataframe_tester.py
@@ -345,9 +345,9 @@ class DataFrameTester:
             )
 
             # Expression to count non-null entries
-            n_tests_expr = F.count(F.col(col_name).isNotNull()).alias(
-                f"{col_name}_n_tests"
-            )
+            n_tests_expr = F.sum(
+                F.when(F.col(col_name).isNotNull(), 1).otherwise(0)
+            ).alias(f"{col_name}_n_tests")
             agg_exprs.append(n_tests_expr)
 
             if is_boolean:


### PR DESCRIPTION
n_tests incorrectly also counted `None` values. Fixed it and added pytests for it.

1. **Updated Expression:**
   ```python
   n_tests_expr = F.sum(
                   F.when(F.col(col_name).isNotNull(), 1).otherwise(0)
               ).alias(f"{col_name}_n_tests")
   ```
   - **What it does:** This expression uses `F.when()` to check if the column value is not null (`F.col(col_name).isNotNull()`). If it is not null, it assigns a value of `1`, and if it is null, it assigns `0`. Then, it sums these values using `F.sum()`, resulting in a count of non-null values.
   - **Strengths:** This method explicitly handles null checks and ensures that the count includes only rows where the column is not null.
   - **Behavior:** This approach will correctly count the number of non-null values because the `when` clause is used to assign `1` for non-null values and `0` for nulls, and then sums them up.

2. **Previous Expression:**
   ```python
   n_tests_expr = F.count(F.col(col_name).isNotNull()).alias(f"{col_name}_n_tests")
   ```
   - **What it does:** This expression tries to count the number of non-null values by using `F.count()` on the result of `F.col(col_name).isNotNull()`. 
   - **Issue:** This will **not** work as intended. `F.count()` in PySpark counts the number of non-null rows in a DataFrame, but it cannot directly count a boolean expression like `F.col(col_name).isNotNull()`. The `count()` function is typically used with columns, not conditions. So this will count all rows, not just the non-null ones.
   - **Behavior:** This will likely lead to incorrect results or may even cause an error, as `F.count()` expects a column, not a boolean condition.

### Summary:
- The **first expression** is the correct way to count non-null values, as it explicitly handles null checking and sums up the occurrences.
- The **second expression** is incorrect because `F.count()` expects a column, and `F.col(col_name).isNotNull()` is a boolean expression, which won't work as intended.