### PR TITLE
support for context-columns

### DIFF
--- a/src/testframework/dataquality/dataframe/dataframe_tester.py
+++ b/src/testframework/dataquality/dataframe/dataframe_tester.py
@@ -28,6 +28,7 @@ class DataFrameTester:
         df (DataFrame): The pyspark DataFrame to test.
         primary_key (Union[str, list[str]]): The name of the column(s) used as a primary key. The column should contain only unique values. Rows of which all primary keys are null are deleted.
         spark (SparkSession): The SparkSession to use for the tests.
+        context_cols (Optional[list[str]]): Additional columns to include in the results DataFrame alongside the primary key. Columns that overlap with primary_key are automatically filtered out. Defaults to None.
     """
 
     def __init__(
@@ -35,12 +36,13 @@ class DataFrameTester:
         df: DataFrame,
         primary_key: Union[str, list[str]],
         spark: SparkSession,
+        context_cols: Optional[list[str]] = None,
     ) -> None:
         self.primary_key = (
             [primary_key] if isinstance(primary_key, str) else primary_key
         )
         self.df = self._check_primary_key(df)
-        self.results: DataFrame = self.df.select(self.primary_key)
+        self.results: DataFrame = self._initialize_results_dataframe(context_cols)
         self.spark = spark
         self.descriptions: dict[str, str] = {}
 
@@ -56,6 +58,41 @@ class DataFrameTester:
             DataFrame: The loaded Spark DataFrame.
         """
         return df.select(cls.potential_primary_keys(df))
+
+    def _initialize_results_dataframe(
+        self, context_cols: Optional[list[str]]
+    ) -> DataFrame:
+        """
+        Initialize the results DataFrame with primary key and optional extra columns.
+
+        Args:
+            context_cols (Optional[list[str]]): Additional columns to include alongside primary key.
+
+        Returns:
+            DataFrame: The initialized results DataFrame.
+
+        Raises:
+            ValueError: If any columns in context_cols are not found in the DataFrame.
+        """
+        if context_cols:
+            # Check all columns at once for better performance
+            missing_cols = [col for col in context_cols if col not in self.df.columns]
+            if missing_cols:
+                available_cols = sorted(self.df.columns)
+                raise ValueError(
+                    f"Column(s) {missing_cols} not found in DataFrame. "
+                    f"Available columns: {available_cols}"
+                )
+
+            # Remove duplicates and preserve order while avoiding primary key duplication
+            context_cols_filtered = [
+                col for col in context_cols if col not in self.primary_key
+            ]
+            self.non_test_cols = self.primary_key + context_cols_filtered
+
+        else:
+            self.non_test_cols = self.primary_key
+        return self.df.select(self.non_test_cols)
 
     def _check_primary_key(self, df: DataFrame) -> DataFrame:
         """
@@ -179,17 +216,17 @@ class DataFrameTester:
             self.df.filter(filter_rows) if filter_rows is not None else self.df
         )
 
-        test_result = test.test(filtered_df, col, self.primary_key, nullable)
+        test_result = test.test(filtered_df, col, self.non_test_cols, nullable)
+        test_name = test.generate_result_col_name(col)
+        test_result = test_result.select(self.non_test_cols + [test_name])
 
         if not dummy_run:
-            test_name = test.generate_result_col_name(col)
-
             self.descriptions[test_name] = (
                 description if description else f"{col}__{test}"
             )
 
-            new_test_results = self.results.drop(test_name)
-            new_test_results = new_test_results.join(
+            old_test_results = self.results.drop(test_name)
+            new_test_results = old_test_results.join(
                 test_result.select(self.primary_key + [test_name]),
                 on=self.primary_key,
                 how="left",
@@ -273,8 +310,8 @@ class DataFrameTester:
 
         self.descriptions[name] = description if description else name
 
-        new_test_results = self.results.drop(name)
-        new_test_results = new_test_results.join(
+        old_test_results = self.results.drop(name)
+        new_test_results = old_test_results.join(
             result.select(self.primary_key + [name]),
             on=self.primary_key,
             how="left",
@@ -289,13 +326,13 @@ class DataFrameTester:
             new_test_results = new_test_results.filter(F.col(name) == F.lit(False))
 
         if return_extra_cols:
-            return new_test_results.select(*self.primary_key, name).join(
+            return new_test_results.join(
                 self.df.select(*self.primary_key, *return_extra_cols),
                 on=self.primary_key,
                 how="left",
             )
 
-        return new_test_results.select(*self.primary_key, name)
+        return new_test_results.select(self.non_test_cols + [name])
 
     @property
     def summary(self) -> DataFrame:
@@ -325,7 +362,7 @@ class DataFrameTester:
         """
         df = self.results
 
-        test_columns = df.columns[1:]  # Exclude the first column
+        test_columns = df.columns[len(self.non_test_cols) :]  # Exclude non-test columns
 
         # Lists to collect aggregation expressions and column info
         agg_exprs = []
@@ -439,8 +476,8 @@ class DataFrameTester:
             DataFrame: A DataFrame containing only the rows where no test has failed.
         """
         conditions = [
-            (F.col(col) != F.lit(False) | F.col(col).isNull())
-            for col in self.results.columns[1:]
+            ((F.col(col) != F.lit(False)) | F.col(col).isNull())
+            for col in self.results.columns[len(self.non_test_cols) :]
             if isinstance(self.results.schema[col].dataType, BooleanType)
         ]
 
@@ -462,7 +499,7 @@ class DataFrameTester:
         """
         conditions = [
             F.col(col) == F.lit(False)
-            for col in self.results.columns[1:]
+            for col in self.results.columns[len(self.non_test_cols) :]
             if isinstance(self.results.schema[col].dataType, BooleanType)
         ]
 

--- a/src/testframework/dataquality/dataframe/dataframe_tester.py
+++ b/src/testframework/dataquality/dataframe/dataframe_tester.py
@@ -427,12 +427,8 @@ class DataFrameTester:
             if is_boolean:
                 n_passed = agg_results[f"{col_name}_n_passed"]
                 n_failed = agg_results[f"{col_name}_n_failed"]
-                percentage_passed = (
-                    round(n_passed / n_tests * 100, 2) if n_tests > 0 else 0.0
-                )
-                percentage_failed = (
-                    round(n_failed / n_tests * 100, 2) if n_tests > 0 else 0.0
-                )
+                percentage_passed = n_passed / n_tests * 100 if n_tests > 0 else 0.0
+                percentage_failed = n_failed / n_tests * 100 if n_tests > 0 else 0.0
             else:
                 n_passed = None
                 n_failed = None

--- a/tests/dataquality/dataframe/test_DataFrameTester.py
+++ b/tests/dataquality/dataframe/test_DataFrameTester.py
@@ -94,6 +94,19 @@ def test_test_method_with_return_extra_cols(sample_df, spark):
     assert result_df.filter(result_df["name"].isNotNull()).count() == 5
 
 
+def test_test_method_with_context_cols(sample_df, spark):
+    tester = DataFrameTester(
+        df=sample_df, primary_key="id", spark=spark, context_cols=["name"]
+    )
+    valid_numeric_range = ValidNumericRange(min_value=30)
+    result_df = tester.test(col="value", test=valid_numeric_range, nullable=True)
+
+    # The returned result from .test should include non-test columns (primary key + extra)
+    assert "name" in result_df.columns
+    # The internal results should also keep the extra saved column
+    assert "name" in tester.results.columns
+
+
 def test_test_method_with_dummy_run(sample_df, spark):
     tester = DataFrameTester(df=sample_df, primary_key="id", spark=spark)
     valid_numeric_range = ValidNumericRange(min_value=30)
@@ -138,6 +151,29 @@ def test_add_custom_test_result(sample_df, spark):
     assert tester.descriptions["custom_test"] == "This is a custom test"
     assert updated_results.filter(col("custom_test")).count() == 2
     assert updated_results.filter(~col("custom_test")).count() == 3
+
+
+def test_add_custom_test_result_with_context_cols_and_return_extra(sample_df, spark):
+    tester = DataFrameTester(
+        df=sample_df, primary_key="id", spark=spark, context_cols=["name"]
+    )
+    custom_test_data = [(1, True), (2, False), (3, True), (4, False)]
+    custom_test_columns = ["id", "custom_test"]
+    custom_test_result = spark.createDataFrame(custom_test_data, custom_test_columns)
+
+    updated_results = tester.add_custom_test_result(
+        result=custom_test_result,
+        name="custom_test",
+        description="This is a custom test",
+        return_extra_cols=["value"],
+    )
+
+    # Should include the saved extra col ("name") and requested return extra col ("value")
+    assert "custom_test" in updated_results.columns
+    assert "name" in updated_results.columns
+    assert "value" in updated_results.columns
+    # The internal results should retain the saved extra column as well
+    assert "name" in tester.results.columns
 
 
 def test_add_custom_test_result_return_extra_cols(sample_df, spark):


### PR DESCRIPTION
### What ✨
- Add `context_cols` to `DataFrameTester` to persist specified context columns alongside the primary key in `results` (validated, de-duped vs primary key, order preserved).
- Fix operator precedence in `passed_tests` so per-column condition is evaluated as `(col != False) OR (col IS NULL)` before combining across columns.
- Change `summary` percentages to no longer round; percentages now return full-precision floats.
- Add tests for `context_cols` usage with `.test()` and `.add_custom_test_result()`.

### Why 💡
- Make it easy to carry key context fields through test outputs for reporting/filtering.
- Ensure `passed_tests` logic correctly treats Null as pass-through and False as failure.
- Leave percentage formatting to consumers, avoiding premature rounding.

### Impact 🚀
- No breaking change to main (parameter is new).
- Percentages may show more decimals; callers can format as needed.

### Tests ✅
- `test_test_method_with_context_cols`
- `test_add_custom_test_result_with_context_cols_and_return_extra`